### PR TITLE
Refactor control requests and JSON parsing, add polling options docs and audit notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ No further configuration is needed.
 
 ## 📌 Current limitations
 
-- Only supports a single pump (first device of type `i2d`)
-- No multi-pump support yet (planned for future release)
-- Requires a valid iAquaLink account with a registered iQPump01 pump
-- Only compatible with iQPump01: This integration is designed specifically for the Jandy iQPump01 controller. 
-- Refresh rate is limited to 60 seconds: To avoid overloading the vendor's API and triggering rate limits, the integration uses a caching mechanism with a refresh interval of 60 seconds. All data sensors and status updates rely on this rate.
+- Only `i2d` controllers (iQPump01) are supported; other iAquaLink equipment families are not supported yet.
+- Requires a valid iAquaLink account with at least one registered iQPump01 controller.
+- Multi-pump is supported through multiple integration entries (one per serial), but there is no global cross-pump orchestration view/feature yet.
+- Polling is configurable:
+  - **Normal**: 60s by default (adjustable from 15 to 300s in options),
+  - **Fast refresh** after speed changes: 10s by default for 3 minutes (adjustable from 5 to 60s and 30 to 600s).
+  These guardrails help reduce cloud API rate-limiting risk.
 
 ## 🐞 Debugging
 

--- a/custom_components/iaqualink_iqpump01/api.py
+++ b/custom_components/iaqualink_iqpump01/api.py
@@ -6,6 +6,8 @@ import requests
 _LOGGER = logging.getLogger(__name__)
 REQUEST_TIMEOUT = 15
 REDACTED = "<redacted>"
+CONTROL_USER_AGENT = "iAqualink/934 CFNetwork/3826.500.111.2.2 Darwin/24.4.0"
+CONTROL_ACCEPT_LANGUAGE = "fr-CA,fr;q=0.9"
 SENSITIVE_LOG_KEYS = {
     "accesskeyid",
     "address",
@@ -198,6 +200,49 @@ class IAqualinkClient:
                 f"iAquaLink {method.upper()} request failed"
             ) from err
 
+
+    def _parse_json(self, response, context):
+        try:
+            return response.json()
+        except ValueError as err:
+            raise IAqualinkConnectionError(
+                f"iAquaLink returned invalid JSON during {context}"
+            ) from err
+
+    def _control_url(self):
+        return f"https://r-api.iaqualink.net/v2/devices/{self.serial}/control.json?"
+
+    def _control_headers(self):
+        return {
+            "accept": "*/*",
+            "content-type": "application/json",
+            "cookie": f"session_id={self.session_id}; authentication_token={self.auth_token}",
+            "authorization": self.id_token,
+            "api_key": self.apikey,
+            "user-agent": CONTROL_USER_AGENT,
+            "accept-language": CONTROL_ACCEPT_LANGUAGE,
+            "accept-encoding": "gzip, deflate, br",
+        }
+
+    def _post_control(self, payload, context):
+        control_url = self._control_url()
+        headers = self._control_headers()
+        response = self._request(
+            "post", control_url, check_status=False, headers=headers, json=payload
+        )
+        if response.status_code == 401:
+            _LOGGER.warning("[%s] Token expired, reauthenticating...", context)
+            self.login()
+            headers = self._control_headers()
+            response = self._request(
+                "post",
+                control_url,
+                check_status=False,
+                headers=headers,
+                json=payload,
+            )
+        return response
+
     def login(self):
         _LOGGER.debug(
             "[login] Logging in with email: %s", self._mask_email(self.email)
@@ -215,7 +260,7 @@ class IAqualinkClient:
 
         self._log_response("login", response)
 
-        data = response.json()
+        data = self._parse_json(response, "login")
         try:
             self.auth_token = data["authentication_token"]
             self.session_id = data["session_id"]
@@ -229,7 +274,7 @@ class IAqualinkClient:
 
         self._log_response("device_url", device_list)
 
-        devices_payload = device_list.json()
+        devices_payload = self._parse_json(device_list, "devices list")
         if isinstance(devices_payload, dict):
             devices_payload = devices_payload.get("devices", [])
 
@@ -270,83 +315,34 @@ class IAqualinkClient:
     def refresh_data(self):
         with self._refresh_lock:
             _LOGGER.debug("[refresh_data] Refreshing pump data.")
-            control_url = f"https://r-api.iaqualink.net/v2/devices/{self.serial}/control.json?"
-            headers = {
-                "accept": "*/*",
-                "content-type": "application/json",
-                "cookie": f"session_id={self.session_id}; authentication_token={self.auth_token}",
-                "authorization": self.id_token,
-                "api_key": self.apikey,
-                "user-agent": "iAqualink/934 CFNetwork/3826.500.111.2.2 Darwin/24.4.0",
-                "accept-language": "fr-CA,fr;q=0.9",
-                "accept-encoding": "gzip, deflate, br"
-            }
             payload = {
                 "user_id": str(self.user_id),
                 "command": "/alldata/read"
             }
 
-            resp = self._request(
-                "post", control_url, check_status=False, headers=headers, json=payload
-            )
-            if resp.status_code == 401:
-                _LOGGER.warning("[refresh_data] Token expired during refresh, reauthenticating...")
-                self.login()
-                headers["cookie"] = f"session_id={self.session_id}; authentication_token={self.auth_token}"
-                headers["authorization"] = self.id_token
-                resp = self._request(
-                    "post",
-                    control_url,
-                    check_status=False,
-                    headers=headers,
-                    json=payload,
-                )
+            resp = self._post_control(payload, "refresh_data")
 
             self._log_response("refresh_data", resp)
             self._raise_for_status(resp, "refresh_data")
 
-            self.data = resp.json().get("alldata", {})
+            response_data = self._parse_json(resp, "refresh_data")
+            self.data = response_data.get("alldata", {})
             return self.data
 
     def _send_command(self, command, param):
-        control_url = f"https://r-api.iaqualink.net/v2/devices/{self.serial}/control.json?"
-        headers = {
-            "accept": "*/*",
-            "content-type": "application/json",
-            "cookie": f"session_id={self.session_id}; authentication_token={self.auth_token}",
-            "authorization": self.id_token,
-            "api_key": self.apikey,
-            "user-agent": "iAqualink/934 CFNetwork/3826.500.111.2.2 Darwin/24.4.0",
-            "accept-language": "fr-CA,fr;q=0.9",
-            "accept-encoding": "gzip, deflate, br"
-        }
         payload = {
             "user_id": str(self.user_id),
             "command": command,
             "params": param,
         }
         _LOGGER.debug("[_send_command] POST %s | %s", command, param)
-        resp = self._request(
-            "post", control_url, check_status=False, headers=headers, json=payload
-        )
-        if resp.status_code == 401:
-            _LOGGER.warning("[_send_command] Token expired during command, reauthenticating...")
-            self.login()
-            headers["cookie"] = f"session_id={self.session_id}; authentication_token={self.auth_token}"
-            headers["authorization"] = self.id_token
-            resp = self._request(
-                "post",
-                control_url,
-                check_status=False,
-                headers=headers,
-                json=payload,
-            )
+        resp = self._post_control(payload, "_send_command")
 
         _LOGGER.debug("[_send_command] Response status: %s", resp.status_code)
         self._log_response("_send_command", resp)
         self._raise_for_status(resp, command)
 
-        data = resp.json()
+        data = self._parse_json(resp, "_send_command")
         command_key = command.strip("/").split("/")[0]
         expected_value = param.removeprefix("value=") if param.startswith("value=") else None
         returned_value = data.get(command_key, {}).get("value")

--- a/custom_components/iaqualink_iqpump01/coordinator.py
+++ b/custom_components/iaqualink_iqpump01/coordinator.py
@@ -7,7 +7,12 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .api import IAqualinkAuthError, IAqualinkClient
+from .api import (
+    IAqualinkAuthError,
+    IAqualinkClient,
+    IAqualinkCommandError,
+    IAqualinkConnectionError,
+)
 from .const import (
     CONF_FAST_REFRESH_DURATION_SECONDS,
     CONF_FAST_UPDATE_INTERVAL_SECONDS,
@@ -66,8 +71,12 @@ class IAqualinkPumpCoordinator(DataUpdateCoordinator):
             return await self.hass.async_add_executor_job(self.client.refresh_data)
         except IAqualinkAuthError as err:
             raise ConfigEntryAuthFailed("iAquaLink authentication failed") from err
+        except IAqualinkConnectionError as err:
+            raise UpdateFailed(f"Network/HTTP error communicating with iAquaLink: {err}") from err
+        except IAqualinkCommandError as err:
+            raise UpdateFailed(f"Command validation failed: {err}") from err
         except Exception as err:
-            raise UpdateFailed(f"Error communicating with iAquaLink: {err}") from err
+            raise UpdateFailed(f"Unexpected error communicating with iAquaLink: {err}") from err
 
     @callback
     def enable_fast_refresh(self) -> None:

--- a/docs/AUDIT_RECOMMENDATIONS.md
+++ b/docs/AUDIT_RECOMMENDATIONS.md
@@ -1,0 +1,68 @@
+# Audit technique du projet `iaqualink_iqpump01`
+
+Date: 2026-05-13
+
+## Portée
+
+- Revue statique du code Python de l'intégration Home Assistant.
+- Vérification de la structure du composant custom, de la robustesse API et des paramètres exposés à l'utilisateur.
+- Contrôle rapide de validité syntaxique Python.
+
+## Points forts
+
+1. **Gestion d'erreurs API claire et typée** (`IAqualinkAuthError`, `IAqualinkConnectionError`, etc.), ce qui facilite un comportement cohérent côté config flow et coordinator.
+2. **Effort sérieux de redaction des logs sensibles**, incluant token/session/email/SSID et structures imbriquées.
+3. **Bonne UX Home Assistant** avec options de polling normal/rapide et sélection de pompe quand plusieurs i2d existent.
+
+## Risques / dette technique identifiés
+
+### 1) Dépendance HTTP synchrone `requests` au lieu de `aiohttp`
+Le client utilise `requests` dans des appels bloquants, compensés via `async_add_executor_job`. Cela fonctionne, mais reste moins idiomatique en environnement Home Assistant (asynchrone natif), augmente le coût threadpool, et complique l'observabilité/résilience réseau.
+
+**Recommandation**: migrer progressivement vers `aiohttp` avec session partagée Home Assistant (`async_get_clientsession`) et timeouts explicites.
+
+### 2) Entêtes HTTP figées et potentiellement fragiles
+Le `user-agent` et `accept-language` sont codés en dur, ce qui peut casser si l'API amont devient plus stricte, et augmente le risque de maintenance.
+
+**Recommandation**: centraliser ces entêtes dans des constantes, documenter le rationnel, et minimiser au strict nécessaire.
+
+### 3) Parsing JSON sans garde sur certains chemins
+Plusieurs `response.json()` sont appelés sans protection contre payload invalide ou inattendu.
+
+**Recommandation**: encapsuler la lecture JSON dans une méthode robuste qui lève une exception domaine (`IAqualinkConnectionError`) avec contexte.
+
+### 4) Vérification de commande partielle
+La validation post-commande compare uniquement une clé/valeur attendue. Si l'API répond un format différent (ou ACK différé), cela peut créer des faux négatifs.
+
+**Recommandation**: introduire une stratégie de confirmation configurable (best-effort), par exemple relecture d'état après commande avec petite temporisation.
+
+### 5) Gestion générique des exceptions dans le coordinator
+`except Exception` dans `_async_update_data` masque l'origine précise de certains échecs.
+
+**Recommandation**: capturer explicitement `IAqualinkConnectionError` / `IAqualinkCommandError` avant le catch-all, et enrichir les messages.
+
+## Recommandations prioritaires (ordre d'implémentation)
+
+1. **P0 - Fiabilité runtime**: sécuriser le parsing JSON + granulariser les erreurs coordinator.
+2. **P1 - Maintenabilité**: factoriser `control_url`/headers/payloads communs dans helpers privés.
+3. **P1 - Perf/architecture HA**: planifier migration `requests` -> `aiohttp`.
+4. **P2 - Qualité**: ajouter tests unitaires ciblés (redaction, sélection device, conversion options, erreurs HTTP/timeout).
+5. **P2 - Ops**: ajouter CI minimale (lint + tests + validation manifest).
+
+## Plan de tests recommandé
+
+- Tests unitaires `api.py`:
+  - redaction de clés sensibles simples et imbriquées,
+  - gestion timeout + 401/403 + autres HTTP,
+  - fallback quand JSON invalide.
+- Tests config flow:
+  - compte sans device,
+  - multi-device et sélection série,
+  - duplication via unique_id.
+- Tests coordinator:
+  - bascule fast refresh et retour intervalle normal,
+  - conversion erreurs vers `ConfigEntryAuthFailed` / `UpdateFailed`.
+
+## Conclusion
+
+Le composant est déjà **fonctionnel et bien structuré** pour un projet communautaire, avec une bonne attention à la sécurité des logs et à l'UX Home Assistant. Les gains les plus importants se situent sur la robustesse réseau/JSON, l'alignement async natif HA, et la couverture de tests automatisés.


### PR DESCRIPTION
### Motivation

- Improve robustness of API interactions by centralizing control request headers and handling token refresh in one place. 
- Harden JSON parsing to avoid uncaught `ValueError` on invalid payloads and surface clearer connection errors. 
- Expose clearer polling behavior and multi-pump support details in documentation and capture audit findings.

### Description

- Introduced `_control_url`, `_control_headers`, and `_post_control` to centralize control endpoint construction, headers (including `CONTROL_USER_AGENT` and `CONTROL_ACCEPT_LANGUAGE`), and automatic re-authentication on 401 responses. 
- Added `_parse_json` helper that wraps `response.json()` and raises `IAqualinkConnectionError` with context on invalid JSON, and replaced direct `response.json()` calls with this helper in `login`, `refresh_data`, and `_send_command`. 
- Replaced duplicated header/payload logic in `refresh_data` and `_send_command` with `_post_control`, and improved command validation flow to use parsed JSON. 
- Updated `coordinator.py` to import `IAqualinkCommandError` and `IAqualinkConnectionError` and to surface more specific `UpdateFailed` messages for connection and command validation errors. 
- Updated `README.md` to clarify supported device families, multi-pump handling, and detailed polling options (normal/fast), and added `docs/AUDIT_RECOMMENDATIONS.md` with a security/architecture review and recommendations.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ea7e1d2c832c87dc9150203f2e94)